### PR TITLE
Fix UIBuildMacros.hpp for MSVC

### DIFF
--- a/UIBuildMacros.hpp
+++ b/UIBuildMacros.hpp
@@ -8,10 +8,14 @@
         return *this;\
     }
 
+#define arg_1(t0) (t0 p0)
+#define arg_2(t0, t1) (t0 p0, t1 p1)
+#define arg_3(t0, t1, t2) (t0 p0, t1 p1, t2 p2)
+
 #define setter_0(base, name, oldname) setter_n(base, name, oldname, (void), ())
-#define setter_1(base, name, oldname, t0) setter_n(base, name, oldname, (t0 p0), (p0))
-#define setter_2(base, name, oldname, t0, t1) setter_n(base, name, oldname, (t0 p0, t1 p1), (p0, p1))
-#define setter_3(base, name, oldname, t0, t1, t2) setter_n(base, name, oldname, (t0 p0, t1 p1, t2 p2), (p0, p1, p2))
+#define setter_1(base, name, oldname, t0) setter_n(base, name, oldname, arg_1(t0), (p0))
+#define setter_2(base, name, oldname, t0, t1) setter_n(base, name, oldname, arg_2(t0, t1), (p0, p1))
+#define setter_3(base, name, oldname, t0, t1, t2) setter_n(base, name, oldname, arg_3(t0, t1, t2), (p0, p1, p2))
 
 
 #define NLIST(p0, p1, p2, p3, N, ...) N


### PR DESCRIPTION
UIBuilder didn't work with MSVC due to a [really weird preprocessor bug](https://developercommunity.visualstudio.com/t/msvc-preprocessor-not-standards-compliant/982055)
It does work when activating the flag `/Zc:preprocessor` but CMake doesn't seem to be able to activate it

However, we can wrap the arguments into a new macro for each setter and it suddenly works!