### PR TITLE
Update CMake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.21)
 project(UIBuilder VERSION 1.0.0 LANGUAGES CXX)
 
 add_library(${PROJECT_NAME} INTERFACE)


### PR DESCRIPTION
On newer versions of CMake, UIBuilder cannot compile.
> Compatibility with CMake < 3.5 has been removed from CMake.

I've bumped it to 3.21, since that's the version in the geode mod template